### PR TITLE
Adds parts of EcoscoreData to api

### DIFF
--- a/openfoodfacts-csharp/Models/Adjustments.cs
+++ b/openfoodfacts-csharp/Models/Adjustments.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Newtonsoft.Json;
+
+namespace OpenFoodFactsCSharp.Models
+{
+    public class Adjustments
+    {
+        [JsonProperty("packaging")]
+        public Packaging Packaging { get; set; }
+    }
+}

--- a/openfoodfacts-csharp/Models/EcoscoreData.cs
+++ b/openfoodfacts-csharp/Models/EcoscoreData.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Newtonsoft.Json;
+
+namespace OpenFoodFactsCSharp.Models
+{
+    public class EcoscoreData
+    {
+        [JsonProperty("adjustments")]
+        public Adjustments Adjustments { get; set; }
+    }
+}

--- a/openfoodfacts-csharp/Models/Packaging.cs
+++ b/openfoodfacts-csharp/Models/Packaging.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace OpenFoodFactsCSharp.Models
+{
+    public class Packaging
+    {
+        [JsonProperty("non_recyclable_and_non_biodegradable_materials")]
+        public string NonRecyclableAndNonBiodegradableMaterials {get;set;}
+        
+        [JsonProperty("packagings")]
+        public Packagings[] Packagings { get;set;}
+    }
+
+    public class Packagings
+    {
+        [JsonProperty("ecoscore_material_score")]
+        public decimal EcoscoreMaterialScore {get;set;}
+        [JsonProperty("ecoscore_shape_ratio")]
+        public decimal EcoscoreShapeRatio {get;set;}
+        [JsonProperty("material")]
+        public string Material {get;set;}
+        [JsonProperty("material_shape")]
+        public string MaterialShape {get;set;}
+        [JsonProperty("non_recyclable_and_non_biodegradable")]
+        public string NonRecyclableAndNonBiodegradable {get;set; }
+        [JsonProperty("shape")]
+        public string Shape { get; set; }
+
+    }
+}

--- a/openfoodfacts-csharp/Models/Product.cs
+++ b/openfoodfacts-csharp/Models/Product.cs
@@ -283,6 +283,9 @@ namespace OpenFoodFactsCSharp.Models
         public string[] OtherNutritionalSubstancesTags { get; set; }
         [JsonProperty("packaging_debug_tags")]
         public string[] PackagingDebugTags { get; set; }
+        [JsonProperty("ecoscore_data")]
+        public EcoscoreData EcoscoreData { get; set; }
+
         [JsonProperty("packaging_tags")]
         public string[] PackagingTags { get; set; }
         [JsonProperty("photographers_tags")]


### PR DESCRIPTION
With the purpose of accessing some of the recycling data

### What
- Adds some of the child types of ecoscore_data to enable access to packaging information 
- No unit tests added due to minimal nature of existing unit test code but has been tested with a number of barcodes.